### PR TITLE
fix(storybook): update @komune-io/g2 dependency version to use a caret range

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -27,6 +27,7 @@ jobs:
       with-chromatic: false
       storybook-dir: storybook
       storybook-static-dir: storybook-static
+      with-setup-npm-github-pkg: 'true'
     secrets:
       NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -72,21 +72,25 @@ docker-keycloak-auth-push:
 lint: lint-libs
 build: build-libs
 test: test-libs
-package: package-libs
+publish: publish-libs
+promote: promote-libs
 
 lint-libs:
 	echo 'No Lint'
 	#./gradlew detekt
 
 build-libs:
-	./gradlew build --scan -x test
+	./gradlew build publishToMavenLocal -x test
 
 test-libs:
 	echo 'No Tests'
 #	./gradlew test
 
-package-libs: build-libs
-	./gradlew publishToMavenLocal publish
+publish-libs:
+	VERSION=$(VERSION) PKG_MAVEN_REPO=github ./gradlew publish --info
+
+promote-libs:
+	VERSION=$(VERSION) PKG_MAVEN_REPO=sonatype_oss ./gradlew publish
 
 version:
 	@VERSION=$$(cat VERSION); \

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -8,7 +8,7 @@
   "source": "src/index.ts",
   "types": "src/index.ts",
   "devDependencies": {
-    "@komune-io/g2": "0.5.0-alpha.1",
+    "@komune-io/g2": "^0.5.0-alpha.1",
     "@komune-io/g2-storybook-documentation": "^0.5.0-alpha.1",
     "@storybook/addon-actions": "7.4.5",
     "@storybook/addon-docs": "7.4.5",


### PR DESCRIPTION
The dependency version for @komune-io/g2 has been updated to use a caret range (^0.5.0-alpha.1) to allow for future compatible updates within the same major version. This ensures that the latest compatible version of the dependency will be used when installing or updating packages.