### PR TITLE
build: add additional Maven repositories for dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+VERSION = $(shell cat VERSION)
+
 include ./gradle.properties
 
 STORYBOOK_DOCKERFILE	:= infra/docker/storybook/Dockerfile

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,15 @@ plugins {
 allprojects {
     group = "io.komune.im"
     version = System.getenv("VERSION") ?: "latest"
+
+    repositories {
+        mavenCentral()
+        mavenLocal()
+        maven { url = uri("https://s01.oss.sonatype.org/service/local/repositories/releases/content") }
+        maven { url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots") }
+    }
 }
+
 
 fixers {
     d2 {

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -8,6 +8,14 @@ dependencies {
     implementation("io.komune.fixers.gradle:dependencies:0.17.0-SNAPSHOT")
 }
 
+repositories {
+    mavenCentral()
+    mavenLocal()
+    maven { url = uri("https://s01.oss.sonatype.org/service/local/repositories/releases/content") }
+    maven { url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots") }
+}
+
+
 loadGradleProperties()
 fun Project.loadGradleProperties() {
   File("${project.rootProject.rootDir}/../gradle.properties").inputStream().use { stream ->

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,13 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenLocal()
+        mavenCentral()
+        maven { url = uri("https://s01.oss.sonatype.org/service/local/repositories/releases/content") }
+        maven { url = uri("https://s01.oss.sonatype.org/content/repositories/snapshots") }
+    }
+}
+
 
 rootProject.name = "connect-im"
 


### PR DESCRIPTION
The commit adds additional Maven repositories to the build.gradle.kts, buildSrc/build.gradle.kts, and settings.gradle.kts files. These repositories include mavenCentral(), mavenLocal(), and two Sonatype repositories to ensure that all necessary dependencies can be resolved during the build process. This change improves the build process by providing more options for resolving dependencies.