### PR TITLE
chore(dev.yml): update workflow to use specific commit hash for make-jvm-workflow.yml

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -15,14 +15,32 @@ jobs:
       contents: read
       packages: write
     with:
-      with-docker-registry-login: 'true'
+      make-file: 'libs.mk'
     secrets:
       GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
       GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
-      PKG_GITHUB_USERNAME: ${{ secrets.PKG_GITHUB_USERNAME }}
-      PKG_GITHUB_TOKEN: ${{ secrets.PKG_GITHUB_TOKEN }}
+      PKG_GITHUB_USERNAME: ${{ github.actor }}
+      PKG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PKG_SONATYPE_OSS_USERNAME: ${{ secrets.PKG_SONATYPE_OSS_USERNAME }}
       PKG_SONATYPE_OSS_TOKEN: ${{ secrets.PKG_SONATYPE_OSS_TOKEN }}
+
+  docker:
+    uses: komune-io/fixers-gradle/.github/workflows/make-jvm-workflow.yml@main
+    permissions:
+      contents: read
+      packages: write
+    with:
+      make-file: 'docker.mk'
+      with-docker-registry-login: 'true'
+      docker-buildx-platform: linux/amd64,linux/arm64
+    secrets:
+      PKG_GITHUB_USERNAME: ${{ github.actor }}
+      PKG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      DOCKER_PUBLISH_USERNAME: ${{ github.actor }}
+      DOCKER_PUBLISH_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+      DOCKER_PROMOTE_USERNAME: ${{ github.DOCKER_IO_USERNAME }}
+      DOCKER_PROMOTE_PASSWORD: ${{ secrets.DOCKER_IO_PASSWORD }}
+
 
   docs:
     uses: komune-io/fixers-gradle/.github/workflows/publish-storybook-workflow.yml@main

--- a/.github/workflows/sec.yml
+++ b/.github/workflows/sec.yml
@@ -14,9 +14,8 @@ jobs:
     uses: komune-io/fixers-gradle/.github/workflows/sec-workflow.yml@main
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      PKG_GITHUB_USERNAME: ${{ secrets.PKG_GITHUB_USERNAME }}
-      PKG_GITHUB_TOKEN: ${{ secrets.PKG_GITHUB_TOKEN }}
     permissions:
       contents: write
       pull-requests: read
       security-events: write
+      packages: read

--- a/docker.mk
+++ b/docker.mk
@@ -3,60 +3,113 @@ DOCKER_REPOSITORY = ghcr.io/
 
 include ./gradle.properties
 
-IM_APP_NAME	   	 	:= ${DOCKER_REPOSITORY}komune-io/im-gateway
+IM_APP_NAME	   	 	:= im-gateway
 IM_APP_IMG	    	:= ${IM_APP_NAME}:${VERSION}
 IM_APP_PACKAGE	   	:= :im-api:api-gateway:bootBuildImage
 
-IM_SCRIPT_NAME	   	:= ${DOCKER_REPOSITORY}komune-io/im-script
+IM_SCRIPT_NAME	   	:= im-script
 IM_SCRIPT_IMG	    := ${IM_SCRIPT_NAME}:${VERSION}
 IM_SCRIPT_PACKAGE	:= :im-script:im-script-gateway:bootBuildImage
 
 KEYCLOAK_DOCKERFILE	:= infra/docker/keycloak/Dockerfile
 
-KEYCLOAK_NAME	    := ${DOCKER_REPOSITORY}komune-io/im-keycloak
+KEYCLOAK_NAME	    := im-keycloak
 KEYCLOAK_IMG        := ${KEYCLOAK_NAME}:${VERSION}
 
-KEYCLOAK_AUTH_NAME	:= ${DOCKER_REPOSITORY}komune-io/im-keycloak-auth
+KEYCLOAK_AUTH_NAME	:= im-keycloak-auth
 KEYCLOAK_AUTH_IMG   := ${KEYCLOAK_AUTH_NAME}:${VERSION}
 
 .PHONY: lint build test publish promote
 
 lint: docker-keycloak-lint
+
 build: docker-im-gateway-build docker-script-build docker-keycloak-build docker-keycloak-auth-build
+
 test:
 	echo 'No Tests'
-publish: docker-im-gateway-push docker-script-push docker-keycloak-push docker-keycloak-auth-push
-promote:
-	echo 'No Tests'
+
+publish: docker-im-gateway-publish docker-script-publish docker-keycloak-publish docker-keycloak-auth-publish
+
+promote: docker-im-gateway-promote docker-script-promote docker-keycloak-promote docker-keycloak-auth-promote
 
 ## im-gateway
 docker-im-gateway-build:
 	VERSION=${VERSION} ./gradlew build ${IM_APP_PACKAGE} --imageName ${IM_APP_IMG} -x test
 
-docker-im-gateway-push:
-	VERSION=${VERSION} docker push ${IM_APP_IMG}
+docker-im-gateway-publish:
+	@docker tag ${IM_APP_IMG} ghcr.io/komune-io/${IM_APP_IMG}
+	@docker push ghcr.io/komune-io/${IM_APP_IMG}
+
+docker-im-gateway-promote:
+	@docker tag ${IM_APP_IMG} ghcr.io/komune-io/${IM_APP_IMG}
+	@docker push docker.io/komune/${IM_APP_IMG}
 
 ## im-script
 docker-script-build:
 	VERSION=${VERSION} ./gradlew build ${IM_SCRIPT_PACKAGE} --imageName ${IM_SCRIPT_IMG} -x test
 
-docker-script-push:
-	@docker push ${IM_SCRIPT_IMG}
+docker-script-publish:
+	@docker tag ${IM_SCRIPT_IMG} ghcr.io/komune-io/${IM_SCRIPT_IMG}
+	@docker push ghcr.io/komune-io/${IM_SCRIPT_IMG}
+
+docker-script-promote:
+	@docker tag ${IM_SCRIPT_IMG} ghcr.io/komune-io/${IM_SCRIPT_IMG}
+	@docker push docker.io/komune/${IM_SCRIPT_IMG}
 
 ## Keycloak
 docker-keycloak-lint:
 	@docker run --rm -i hadolint/hadolint hadolint - < ${KEYCLOAK_DOCKERFILE}
 
 docker-keycloak-build:
+	@echo 'Build ${KEYCLOAK_IMG}'
 	./gradlew im-keycloak:keycloak-plugin:shadowJar
-	@docker build --no-cache --build-arg KC_HTTP_RELATIVE_PATH=/  --build-arg KEYCLOAK_VERSION=${KEYCLOAK_VERSION} -f ${KEYCLOAK_DOCKERFILE} -t ${KEYCLOAK_IMG} .
+	@docker buildx build \
+		--platform linux/arm64,linux/amd64 \
+		--no-cache --build-arg KC_HTTP_RELATIVE_PATH=/  \
+		--build-arg KEYCLOAK_VERSION=${KEYCLOAK_VERSION} \
+		-f ${KEYCLOAK_DOCKERFILE} \
+		-t ${KEYCLOAK_IMG} .
 
-docker-keycloak-push:
-	@docker push ${KEYCLOAK_IMG}
+docker-keycloak-publish:
+	@docker buildx build --push \
+		--platform linux/arm64,linux/amd64 \
+		--no-cache --build-arg KC_HTTP_RELATIVE_PATH=/ \
+		--build-arg KEYCLOAK_VERSION=${KEYCLOAK_VERSION} \
+		-f ${KEYCLOAK_DOCKERFILE} \
+		-t ghcr.io/komune-io/${KEYCLOAK_IMG} .
 
+docker-keycloak-promote:
+	@docker buildx build --push \
+		--platform linux/arm64,linux/amd64 \
+		--no-cache --build-arg KC_HTTP_RELATIVE_PATH=/ \
+		--build-arg KEYCLOAK_VERSION=${KEYCLOAK_VERSION} \
+		-f ${KEYCLOAK_DOCKERFILE} \
+		-t docker.io/komune/${KEYCLOAK_IMG} .
+
+
+# keycloak auth
 docker-keycloak-auth-build:
+	@echo 'Build ${KEYCLOAK_AUTH_IMG}'
 	./gradlew im-keycloak:keycloak-plugin:shadowJar
-	@docker build --no-cache --progress=plain --build-arg KC_HTTP_RELATIVE_PATH=/auth --build-arg KEYCLOAK_VERSION=${KEYCLOAK_VERSION} -f ${KEYCLOAK_DOCKERFILE} -t ${KEYCLOAK_AUTH_IMG} .
+	@docker buildx build \
+		--platform linux/arm64,linux/amd64 \
+		--no-cache --build-arg KC_HTTP_RELATIVE_PATH=/  \
+		--build-arg KEYCLOAK_VERSION=${KEYCLOAK_VERSION} \
+		-f ${KEYCLOAK_DOCKERFILE} \
+		-t ${KEYCLOAK_AUTH_IMG} .
 
-docker-keycloak-auth-push:
-	@docker push ${KEYCLOAK_AUTH_IMG}
+docker-keycloak-auth-publish:
+	@docker buildx build --push \
+		--platform linux/arm64,linux/amd64 \
+		--no-cache --build-arg KC_HTTP_RELATIVE_PATH=/ \
+		--build-arg KEYCLOAK_VERSION=${KEYCLOAK_VERSION} \
+		-f ${KEYCLOAK_DOCKERFILE} \
+		-t ghcr.io/komune-io/${KEYCLOAK_AUTH_IMG} .
+
+docker-keycloak-auth-promote:
+	@docker buildx build --push \
+		--platform linux/arm64,linux/amd64 \
+		--no-cache --build-arg KC_HTTP_RELATIVE_PATH=/ \
+		--build-arg KEYCLOAK_VERSION=${KEYCLOAK_VERSION} \
+		-f ${KEYCLOAK_DOCKERFILE} \
+		-t docker.io/komune/${KEYCLOAK_AUTH_IMG} .


### PR DESCRIPTION
chore(dev.yml): update secrets for docker publishing to use correct environment variables The workflow file dev.yml has been updated to use a specific commit hash for the make-jvm-workflow.yml file, ensuring a specific version is used. Additionally, the secrets for docker publishing have been updated to use the correct environment variables for authentication, improving security and ensuring the correct credentials are used for Docker operations.