### PR TITLE
chore(docker.mk): update docker image repository from ghcr.io to docker.io for consistency

### DIFF
--- a/docker.mk
+++ b/docker.mk
@@ -41,7 +41,7 @@ docker-im-gateway-publish:
 	@docker push ghcr.io/komune-io/${IM_APP_IMG}
 
 docker-im-gateway-promote:
-	@docker tag ${IM_APP_IMG} ghcr.io/komune-io/${IM_APP_IMG}
+	@docker tag ${IM_APP_IMG} docker.io/komune/${IM_APP_IMG}
 	@docker push docker.io/komune/${IM_APP_IMG}
 
 ## im-script
@@ -53,7 +53,7 @@ docker-script-publish:
 	@docker push ghcr.io/komune-io/${IM_SCRIPT_IMG}
 
 docker-script-promote:
-	@docker tag ${IM_SCRIPT_IMG} ghcr.io/komune-io/${IM_SCRIPT_IMG}
+	@docker tag ${IM_SCRIPT_IMG} docker.io/komune/${IM_SCRIPT_IMG}
 	@docker push docker.io/komune/${IM_SCRIPT_IMG}
 
 ## Keycloak


### PR DESCRIPTION
The docker image repository for both IM_APP_IMG and IM_SCRIPT_IMG has been updated from ghcr.io to docker.io to maintain consistency across all docker image repositories used in the project.