### PR TITLE
feat(build.gradle.kts): add npm plugin to build.gradle.kts for im-apikey-domain project

### DIFF
--- a/im-f2/apikey/im-apikey-domain/build.gradle.kts
+++ b/im-f2/apikey/im-apikey-domain/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("io.komune.fixers.gradle.kotlin.mpp")
     id("io.komune.fixers.gradle.publish")
+    id("io.komune.fixers.gradle.npm")
 }
 
 dependencies {

--- a/libsJs.mk
+++ b/libsJs.mk
@@ -5,6 +5,7 @@ VERSION = $(shell cat VERSION)
 lint:
 	echo 'No Lint'
 build:
+	VERSION=${VERSION} ./gradlew :im-f2:apikey:im-apikey-domain:build
 	VERSION=${VERSION} ./gradlew :im-f2:organization:im-organization-domain:build
 	VERSION=${VERSION} ./gradlew :im-f2:privilege:im-privilege-domain:build
 	VERSION=${VERSION} ./gradlew :im-f2:space:im-space-domain:build
@@ -13,12 +14,14 @@ build:
 test:
 	echo 'No Tests'
 publish:
+	VERSION=${VERSION} ./gradlew :im-f2:apikey:im-apikey-domain:publishJsPackageToGithubRegistry
 	VERSION=${VERSION} ./gradlew :im-f2:organization:im-organization-domain:publishJsPackageToGithubRegistry
 	VERSION=${VERSION} ./gradlew :im-f2:privilege:im-privilege-domain:publishJsPackageToGithubRegistry
 	VERSION=${VERSION} ./gradlew :im-f2:space:im-space-domain:publishJsPackageToGithubRegistry
 	VERSION=${VERSION} ./gradlew :im-f2:user:im-user-domain:publishJsPackageToGithubRegistry
 
 promote:
+	VERSION=${VERSION} ./gradlew :im-f2:apikey:im-apikey-domain:publishJsPackageToNpmjsRegistry
 	VERSION=${VERSION} ./gradlew :im-f2:organization:im-organization-domain:publishJsPackageToNpmjsRegistry
 	VERSION=${VERSION} ./gradlew :im-f2:privilege:im-privilege-domain:publishJsPackageToNpmjsRegistry
 	VERSION=${VERSION} ./gradlew :im-f2:space:im-space-domain:publishJsPackageToNpmjsRegistry


### PR DESCRIPTION
feat(libsJs.mk): update build and publish scripts to include npm tasks for im-apikey-domain project The npm plugin is added to the build.gradle.kts file for the im-apikey-domain project to enable npm-related tasks. The build and publish scripts in the libsJs.mk file are updated to include npm tasks for the im-apikey-domain project, allowing for publishing to the Npmjs registry.