### PR TITLE
build(libs.mk): enable parallel execution for gradle tasks to improve build performance

### DIFF
--- a/libs.mk
+++ b/libs.mk
@@ -5,7 +5,7 @@ VERSION = $(shell cat VERSION)
 lint:
 	echo 'No Lint'
 build:
-	./gradlew build publishToMavenLocal -x test
+	./gradlew build publishToMavenLocal -Dorg.gradle.parallel=true -x test
 
 test-pre:
 	@make dev up
@@ -18,7 +18,7 @@ test:
 	./gradlew test
 
 publish:
-	VERSION=$(VERSION) PKG_MAVEN_REPO=github ./gradlew publish --info -x publishJsPackageToGithubRegistry -x publishJsPackageToNpmjsRegistry
+	VERSION=$(VERSION) PKG_MAVEN_REPO=github ./gradlew publish -Dorg.gradle.parallel=true -x publishJsPackageToGithubRegistry -x publishJsPackageToNpmjsRegistry
 
 promote:
 	VERSION=$(VERSION) PKG_MAVEN_REPO=sonatype_oss ./gradlew publish


### PR DESCRIPTION
The changes in this commit enable parallel execution for the gradle tasks in the build and publish scripts. This improvement can significantly enhance the build performance by allowing tasks to run concurrently, utilizing available resources more efficiently.