### PR TITLE
style(login.css): fix background image path to correctly reference the image in the img folder

### DIFF
--- a/infra/docker/keycloak/config/themes/im/login/resources/css/login.css
+++ b/infra/docker/keycloak/config/themes/im/login/resources/css/login.css
@@ -38,7 +38,7 @@ button {
 }
 
 .login-pf body {
-  background: url("background.jpeg") no-repeat center center
+  background: url("../img/background.jpeg") no-repeat center center
     fixed;
   background-size: cover;
   height: 100%;


### PR DESCRIPTION
The background image path in the CSS file has been updated to correctly reference the image located in the img folder. This change ensures that the background image is displayed as intended on the login page.