### PR TITLE
Make `rootClient` and `imMasterClient` properties nullable to prevent null pointer exceptions

### DIFF
--- a/im-script/im-script-init/src/main/kotlin/io/komune/im/script/init/ImInitScript.kt
+++ b/im-script/im-script-init/src/main/kotlin/io/komune/im/script/init/ImInitScript.kt
@@ -38,10 +38,10 @@ class ImInitScript(
                 logger.warn("Deprecated: imMasterClient is deprecated and will be removed in the future")
                 logger.warn("Deprecated: use rootClient properties instead")
                 logger.warn("******************************")
-                properties.imMasterClient.initImClient()
+                properties.imMasterClient?.initImClient()
                 logger.info("Initialized imMasterClient")
                 logger.info("Initializing rootClient")
-                properties.rootClient.initImClient()
+                properties.rootClient?.initImClient()
                 logger.info("Initialized rootClient")
             }
         }

--- a/im-script/im-script-init/src/main/kotlin/io/komune/im/script/init/config/ImInitProperties.kt
+++ b/im-script/im-script-init/src/main/kotlin/io/komune/im/script/init/config/ImInitProperties.kt
@@ -4,7 +4,7 @@ import io.komune.im.commons.model.ClientIdentifier
 import io.komune.im.script.core.model.ClientCredentials
 
 data class ImInitProperties(
-    val rootClient: ClientCredentials,
+    val rootClient: ClientCredentials?,
     @Deprecated("Use rootClient instead")
-    val imMasterClient: ClientCredentials
+    val imMasterClient: ClientCredentials?
 )


### PR DESCRIPTION
The `rootClient` and `imMasterClient` properties are now nullable, improving safety during initialization. This change prevents potential null pointer exceptions and ensures the `initImClient()` method is only called when properties are properly initialized.
