### PR TITLE
build(Makefile_libs.mk): enable parallel execution for publish task

### DIFF
--- a/Makefile_libs.mk
+++ b/Makefile_libs.mk
@@ -18,7 +18,7 @@ test:
 	./gradlew test
 
 publish:
-	VERSION=$(VERSION) PKG_MAVEN_REPO=github ./gradlew publish -x publishJsPackageToGithubRegistry -x publishJsPackageToNpmjsRegistry
+	VERSION=$(VERSION) PKG_MAVEN_REPO=github ./gradlew publish -Dorg.gradle.parallel=true -x publishJsPackageToGithubRegistry -x publishJsPackageToNpmjsRegistry
 
 check:
 	./gradlew sonar -Dsonar.token=${SONAR_TOKEN} -Dorg.gradle.parallel=true

--- a/infra/docker-compose/.env_dev
+++ b/infra/docker-compose/.env_dev
@@ -1,7 +1,7 @@
 DOCKER_COMPOSE_FILE=keycloak im-init im-config
 
-DOCKER_REPOSITORY=ghcr.io/komune-io/
-#DOCKER_REPOSITORY=docker.io/komune/
+#DOCKER_REPOSITORY=ghcr.io/komune-io/
+DOCKER_REPOSITORY=docker.io/komune/
 
 DOCKER_NETWORK=im-test-network
 
@@ -23,4 +23,4 @@ AUTH_HOST_URL=http://${KC_HOSTNAME}:8080
 SMTP_HOST=im-fake-smtp
 SMTP_PORT=1025
 
-VERSION_IM=0.19.0-dev-SNAPSHOT
+VERSION_IM=0.19.0-SNAPSHOT


### PR DESCRIPTION
Enable parallel execution in the Gradle publish task to improve build performance by utilizing multiple threads.

chore(.env_dev): switch default Docker repository and update version Change the default Docker repository from GitHub Container Registry to Docker Hub to align with deployment preferences. Update the VERSION_IM to remove the "-dev" suffix, indicating a move towards a more stable release version.