### PR TITLE
Enhance Login Page Styles and Simplify User Interface

### DIFF
--- a/infra/docker/keycloak/config/themes/im/login/login.ftl
+++ b/infra/docker/keycloak/config/themes/im/login/login.ftl
@@ -9,9 +9,9 @@
             <form id="kc-form-login" onsubmit="login.disabled = true; return true;" action="${url.loginAction}" method="post">
                 <div class="${properties.kcFormGroupClass!}">
                     <#if usernameEditDisabled??>
-                        <input tabindex="1" id="username" class="${properties.kcInputClass!}" name="username" value="${(login.username!'')}" type="text" disabled placeholder="Adresse Email ou pseudo" />
+                        <input tabindex="1" id="username" class="${properties.kcInputClass!}" name="username" value="${(login.username!'')}" type="text" disabled placeholder="Adresse Email" />
                     <#else>
-                        <input tabindex="1" id="username" class="${properties.kcInputClass!}" name="username" value="${(login.username!'')}"  type="text" autofocus autocomplete="off" placeholder="Adresse Email ou pseudo"/>
+                        <input tabindex="1" id="username" class="${properties.kcInputClass!}" name="username" value="${(login.username!'')}"  type="text" autofocus autocomplete="off" placeholder="Adresse Email"/>
                     </#if>
                 </div>
 

--- a/infra/docker/keycloak/config/themes/im/login/resources/css/login.css
+++ b/infra/docker/keycloak/config/themes/im/login/resources/css/login.css
@@ -1,4 +1,52 @@
+/*UPDATED CSS*/
+a {
+    text-decoration: underline;
+    font-size: 12px;
+}
+
+.btn-primary {
+    background-color: #124450;
+    border-style: none;
+    border-radius: 5px;
+    height: 40px;
+    background-image: none;
+    color: white;
+    cursor: pointer;
+}
+
+.btn-primary.active, .btn-primary:active, .btn-primary:focus, .btn-primary:hover, .open .dropdown-toggle.btn-primary {
+    background-color: #124450;
+    border-style: none;
+    border-radius: 5px;
+    height: 40px;
+}
+
+.form-control {
+    padding-left: 10px;
+    border-radius: 5px;
+    border: 1px solid rgb(197, 199, 208);
+    height: 40px !important;
+    width: 70%;
+    margin-left: 15%;
+}
+
+.form-control:hover {
+    border: 1.5px solid #124450;
+    outline: none;
+}
+
+.form-control:focus-visible {
+    border: 1.5px solid #124450;
+    outline: none;
+}
+
+.form-group {
+    margin-bottom: 10px;
+}
+
+/*FROM LAST VERSION*/
 @import url("https://fonts.googleapis.com/css2?family=Poppins&display=swap");
+
 body {
   margin: 0;
   padding: 0;
@@ -50,21 +98,6 @@ button {
   justify-content: center;
 }
 
-.btn-primary {
-  background-color: #124450;
-  border-style: none;
-  border-radius: 5px;
-  height: 40px;
-  background-image: none;
-}
-
-.btn-primary.active, .btn-primary:active, .btn-primary:focus, .btn-primary:hover, .open .dropdown-toggle.btn-primary {
-    background-color: #124450;
-    border-style: none;
-    border-radius: 5px;
-    height: 40px;
-}
-
 #kc-page-title {
   font-size: 18px;
   margin-bottom: 20px;
@@ -73,10 +106,6 @@ button {
 #logo {
   width: 180px;
   margin-bottom: 20px;
-}
-
-a {
-  text-decoration: underline;
 }
 
 #forgotPassword {
@@ -255,24 +284,6 @@ div.kc-logo-text span {
 
 .required {
   color: #cb2915;
-}
-
-.form-control {
-  border-radius: 5px;
-  border-color: #d3d7da;
-  height: 45px !important;
-  width: 70%;
-  margin-left: 15%;
-}
-
-.form-control:hover {
-  border-color: #d3d7da;
-}
-
-.form-control:focus {
-  box-shadow: none;
-  border-color: #9a9a9a;
-  border-width: 1.5px;
 }
 
 ol#kc-totp-settings {

--- a/infra/docker/keycloak/config/themes/im/login/template.ftl
+++ b/infra/docker/keycloak/config/themes/im/login/template.ftl
@@ -70,33 +70,35 @@
                         <span class="subtitle"><span class="required">*</span> ${msg("requiredFields")}</span>
                     </div>
                     <div class="col-md-10">
-                        <#nested "show-username">
-                        <div class="${properties.kcFormGroupClass!}">
-                            <div id="kc-username">
-                                <label id="kc-attempted-username">${auth.attemptedUsername}</label>
-                                <a id="reset-login" href="${url.loginRestartFlowUrl}">
-                                    <div class="kc-login-tooltip">
-                                        <i class="${properties.kcResetFlowIcon!}"></i>
-                                        <span class="kc-tooltip-text">${msg("restartLoginTooltip")}</span>
-                                    </div>
-                                </a>
-                            </div>
-                        </div>
+<#--                        Disable the following block because username is an UUID-->
+<#--                        <#nested "show-username">-->
+<#--                        <div class="${properties.kcFormGroupClass!}">-->
+<#--                            <div id="kc-username">-->
+<#--                                <label id="kc-attempted-username">${auth.attemptedUsername}</label>-->
+<#--                                <a id="reset-login" href="${url.loginRestartFlowUrl}">-->
+<#--                                    <div class="kc-login-tooltip">-->
+<#--                                        <i class="${properties.kcResetFlowIcon!}"></i>-->
+<#--                                        <span class="kc-tooltip-text">${msg("restartLoginTooltip")}</span>-->
+<#--                                    </div>-->
+<#--                                </a>-->
+<#--                            </div>-->
+<#--                        </div>-->
                     </div>
                 </div>
             <#else>
-                <#nested "show-username">
-                <div class="${properties.kcFormGroupClass!}">
-                    <div id="kc-username">
-                        <label id="kc-attempted-username">${auth.attemptedUsername}</label>
-                        <a id="reset-login" href="${url.loginRestartFlowUrl}">
-                            <div class="kc-login-tooltip">
-                                <i class="${properties.kcResetFlowIcon!}"></i>
-                                <span class="kc-tooltip-text">${msg("restartLoginTooltip")}</span>
-                            </div>
-                        </a>
-                    </div>
-                </div>
+<#--                Disable the following block because username is an UUID-->
+<#--                <#nested "show-username">-->
+<#--                <div class="${properties.kcFormGroupClass!}">-->
+<#--                    <div id="kc-username">-->
+<#--                        <label id="kc-attempted-username">${auth.attemptedUsername}</label>-->
+<#--                        <a id="reset-login" href="${url.loginRestartFlowUrl}">-->
+<#--                            <div class="kc-login-tooltip">-->
+<#--                                <i class="${properties.kcResetFlowIcon!}"></i>-->
+<#--                                <span class="kc-tooltip-text">${msg("restartLoginTooltip")}</span>-->
+<#--                            </div>-->
+<#--                        </a>-->
+<#--                    </div>-->
+<#--                </div>-->
             </#if>
         </#if>
       </header>


### PR DESCRIPTION
Updated the placeholder text in login.ftl to remove "pseudo" and display only "Adresse Email" for better clarity.
Reorganized and improved the styling of the login page, including link underlines, button updates, and form control appearance, enhancing the overall user experience.
Refactored template.ftl by commenting out the username display block, preventing UUID display and improving user-friendliness.