### PR TITLE
Add Logging for Role Management and Enhance User Policy Enforcement

### DIFF
--- a/im-commons/im-commons-domain/src/commonMain/kotlin/io/komune/im/commons/auth/AuthedUser.kt
+++ b/im-commons/im-commons-domain/src/commonMain/kotlin/io/komune/im/commons/auth/AuthedUser.kt
@@ -11,19 +11,25 @@ interface AuthedUserDTO {
     val id: UserId
     val identifier: String?
     val memberOf: OrganizationId?
-    val roles: Array<String>
+    val roles: Array<String>?
 }
 
 data class AuthedUser(
     override val id: UserId,
     override val identifier: String?,
     override val memberOf: OrganizationId?,
-    override val roles: Array<String>
+    override val roles: Array<String>?
 ): AuthedUserDTO
 
-fun AuthedUserDTO.hasRole(role: String) = role in roles
+fun AuthedUserDTO.hasRole(role: String) = role in (roles ?: emptyArray())
 fun AuthedUserDTO.hasRole(role: ImRole) = hasRole(role.identifier)
-fun AuthedUserDTO.hasRoles(vararg roles: String) = roles.all(this.roles::contains)
+fun AuthedUserDTO.hasRoles(vararg roles: String): Boolean {
+    val myRoles = this.roles ?: emptyArray()
+   return roles.all(myRoles::contains)
+}
 fun AuthedUserDTO.hasRoles(vararg roles: ImRole) = hasRoles(*roles.map(ImRole::identifier).toTypedArray())
-fun AuthedUserDTO.hasOneOfRoles(vararg roles: String) = roles.any(this.roles::contains)
+fun AuthedUserDTO.hasOneOfRoles(vararg roles: String): Boolean {
+    val myRoles = this.roles ?: emptyArray()
+    return roles.any(myRoles::contains)
+}
 fun AuthedUserDTO.hasOneOfRoles(vararg roles: ImRole) = hasOneOfRoles(*roles.map(ImRole::identifier).toTypedArray())

--- a/im-core/user-core/im-user-core-api/src/main/kotlin/io/komune/im/core/user/api/UserCoreAggregateService.kt
+++ b/im-core/user-core/im-user-core-api/src/main/kotlin/io/komune/im/core/user/api/UserCoreAggregateService.kt
@@ -139,7 +139,9 @@ class UserCoreAggregateService : CoreService(CacheName.User) {
     private suspend fun UserRepresentation.assignRoles(roles: List<RoleRepresentation>) {
         val client = keycloakClientProvider.get()
         with(client.user(id).roles().realmLevel()) {
-            val rolesToRemoves = listAll().filter { it.name.startsWith("default-roles") }
+            val allRoles = listAll()
+            logger.info("All roles: ${allRoles.map { it.name }}")
+            val rolesToRemoves = allRoles.filter { it.name.startsWith("default-roles") }
             logger.info("User[$id] Removing roles: ${rolesToRemoves.map { it.name }}")
             remove(rolesToRemoves)
             logger.info("Adding roles: ${roles.map { it.name }}")

--- a/im-core/user-core/im-user-core-api/src/main/kotlin/io/komune/im/core/user/api/UserCoreAggregateService.kt
+++ b/im-core/user-core/im-user-core-api/src/main/kotlin/io/komune/im/core/user/api/UserCoreAggregateService.kt
@@ -18,10 +18,12 @@ import java.util.UUID
 import org.keycloak.representations.idm.CredentialRepresentation
 import org.keycloak.representations.idm.RoleRepresentation
 import org.keycloak.representations.idm.UserRepresentation
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
 class UserCoreAggregateService : CoreService(CacheName.User) {
+    private val logger = LoggerFactory.getLogger(UserCoreAggregateService::class.java)
 
     suspend fun define(command: UserCoreDefineCommand) = mutate(
         command.id.orEmpty(),
@@ -138,7 +140,9 @@ class UserCoreAggregateService : CoreService(CacheName.User) {
         val client = keycloakClientProvider.get()
         with(client.user(id).roles().realmLevel()) {
             val rolesToRemoves = listAll().filter { it.name.startsWith("default-roles") }
+            logger.info("User[$id] Removing roles: ${rolesToRemoves.map { it.name }}")
             remove(rolesToRemoves)
+            logger.info("Adding roles: ${roles.map { it.name }}")
             add(roles)
         }
     }

--- a/im-core/user-core/im-user-core-api/src/main/kotlin/io/komune/im/core/user/api/UserCoreAggregateService.kt
+++ b/im-core/user-core/im-user-core-api/src/main/kotlin/io/komune/im/core/user/api/UserCoreAggregateService.kt
@@ -141,7 +141,7 @@ class UserCoreAggregateService : CoreService(CacheName.User) {
         with(client.user(id).roles().realmLevel()) {
             val allRoles = listAll()
             logger.info("All roles: ${allRoles.map { it.name }}")
-            val rolesToRemoves = allRoles.filter { it.name.startsWith("default-roles") }
+            val rolesToRemoves = allRoles.filterNot { it.name.startsWith("default-roles") }
             logger.info("User[$id] Removing roles: ${rolesToRemoves.map { it.name }}")
             remove(rolesToRemoves)
             logger.info("Adding roles: ${roles.map { it.name }}")

--- a/im-f2/user/im-user-api/src/main/kotlin/io/komune/im/f2/user/api/UserPoliciesEnforcer.kt
+++ b/im-f2/user/im-user-api/src/main/kotlin/io/komune/im/f2/user/api/UserPoliciesEnforcer.kt
@@ -50,7 +50,8 @@ class UserPoliciesEnforcer(
         val user = userFinderService.get(cmd.id)
         logger.debug("Checking if memberOf can be updated for user with roles[${user.roles}] " +
             "and memberOf[${user.memberOf?.id}].")
-        if(UserPolicies.canUpdateMemberOf(authedUser)) {
+
+        if(UserPolicies.canUpdateMemberOf(authedUser) || user.memberOf?.id == cmd.memberOf) {
             cmd
         } else {
             logger.warn("memberOf can't be updated, " +


### PR DESCRIPTION
Introduced logging in `UserCoreAggregateService` to improve traceability of role management actions. Enhanced `UserPoliciesEnforcer` to allow specific `memberOf` updates, improving flexibility and user experience.
