### PR TITLE
chore(gradle.properties): update KEYCLOAK_VERSION from 26.0.0 to 26.0.8-1 for security and stability improvements

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ kotlin.incremental.js.ir=true
 kotlin.js.ir.output.granularity=whole-program
 #org.gradle.parallel=true
 
-KEYCLOAK_VERSION=26.0.0
+KEYCLOAK_VERSION=26.0.8-1


### PR DESCRIPTION
The KEYCLOAK_VERSION is updated to the latest version to incorporate security patches and enhancements, ensuring the application remains secure and stable.