### PR TITLE
chore(workflow): add GitHub username and token to secrets for improved access control

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -40,6 +40,8 @@ jobs:
     secrets:
       NPM_PKG_PUBLISH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       NPM_PKG_PROMOTE_TOKEN: ${{ secrets.NPM_PKG_NPMJS_TOKEN}}
+      PKG_GITHUB_USERNAME: ${{ github.actor }}
+      PKG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   docker:
     uses: komune-io/fixers-gradle/.github/workflows/make-jvm-workflow.yml@main


### PR DESCRIPTION
The addition of PKG_GITHUB_USERNAME and PKG_GITHUB_TOKEN to the secrets allows for better access control and authentication when interacting with GitHub during the workflow. This enhances the security and functionality of the CI/CD process.