### PR TITLE
refactor(user policies): standardize MFA naming to use lowercase 'mfa' for consistency

### DIFF
--- a/im-f2/user/im-user-api/src/main/kotlin/io/komune/im/f2/user/api/UserEndpoint.kt
+++ b/im-f2/user/im-user-api/src/main/kotlin/io/komune/im/f2/user/api/UserEndpoint.kt
@@ -111,7 +111,7 @@ class UserEndpoint(
     @Bean
     override fun userConfigureMFA(): UserConfigureMFAFunction = f2Function { command ->
         logger.info("userConfigureMFA: $command")
-        policiesEnforcer.checkConfigureMFA(command.id)
+        policiesEnforcer.checkConfigureMfa(command.id)
         userAggregateService.configureMFA(command)
     }
 

--- a/im-f2/user/im-user-api/src/main/kotlin/io/komune/im/f2/user/api/UserPoliciesEnforcer.kt
+++ b/im-f2/user/im-user-api/src/main/kotlin/io/komune/im/f2/user/api/UserPoliciesEnforcer.kt
@@ -41,9 +41,9 @@ class UserPoliciesEnforcer(
         enforceMemberOf(cmd)
         enforceRoles(cmd)
     }
-    suspend fun checkConfigureMFA(userId: UserId) = checkAuthed("update an user") { authedUser ->
+    suspend fun checkConfigureMfa(userId: UserId) = checkAuthed("update an user") { authedUser ->
         val user = userFinderService.get(userId)
-        UserPolicies.canUpdate(authedUser, user)
+        UserPolicies.canConfigureMfa(authedUser, user)
     }
     suspend fun checkUpdate(userId: UserId) = checkAuthed("update an user") { authedUser ->
         val user = userFinderService.get(userId)

--- a/im-f2/user/im-user-domain/src/commonMain/kotlin/io/komune/im/f2/user/domain/policies/UserPolicies.kt
+++ b/im-f2/user/im-user-domain/src/commonMain/kotlin/io/komune/im/f2/user/domain/policies/UserPolicies.kt
@@ -50,6 +50,13 @@ object UserPolicies {
     }
 
     /**
+     * User can update mfa
+     */
+    fun canConfigureMfa(authedUser: AuthedUserDTO, user: UserDTO): Boolean {
+        return isMySelf(authedUser, user)
+    }
+
+    /**
      * User can update member of the given user
      */
     fun canUpdateMemberOf(authedUser: AuthedUserDTO): Boolean {


### PR DESCRIPTION


feat(user policies): add canConfigureMfa function to check user permissions for MFA updates The naming of MFA-related functions and variables is standardized to use lowercase 'mfa' for consistency across the codebase. Additionally, a new function `canConfigureMfa` is introduced to encapsulate the logic for checking if a user can update their MFA settings, improving code clarity and maintainability.