### PR TITLE
feat(auth & otp): Enhance OTP authentication flow and standardize MFA handling

### DIFF
--- a/im-f2/space/im-space-lib/src/main/kotlin/io/komune/im/f2/space/lib/flow/AuthenticationFlowDsl.kt
+++ b/im-f2/space/im-space-lib/src/main/kotlin/io/komune/im/f2/space/lib/flow/AuthenticationFlowDsl.kt
@@ -17,8 +17,10 @@ enum class AuthenticationProvider(val id: String) {
     USERNAME_PASSWORD("auth-username-password-form"),
     COOKIE("auth-cookie"),
     OTP_FORM("auth-otp-form"),
+    ALLOW_ACCESS("allow-access-authenticator"),
     IDP_REDIRECT("identity-provider-redirector"),
     CONDITIONAL_USER_ATTRIBUTE("conditional-user-attribute"),
+    CONDITIONAL_LEVEL_OF_AUTHENTICATION("conditional-level-of-authentication"),
     KERBEROS("auth-kerberos");
 
     override fun toString(): String = id

--- a/im-f2/space/im-space-lib/src/main/kotlin/io/komune/im/f2/space/lib/flow/SpaceOtpFlowService.kt
+++ b/im-f2/space/im-space-lib/src/main/kotlin/io/komune/im/f2/space/lib/flow/SpaceOtpFlowService.kt
@@ -41,7 +41,9 @@ class SpaceOtpFlowService {
 
             subFlow("browser-with-conditional-otp-forms", FlowType.BASIC_FLOW, AuthenticationProvider.FORM_FLOW) {
                 execution(AuthenticationProvider.USERNAME_PASSWORD, Requirement.REQUIRED)
-                subFlow("browser-with-conditional-otp-password", FlowType.BASIC_FLOW, AuthenticationProvider.FORM_FLOW) {
+                subFlow(
+                    "browser-with-conditional-otp-password", FlowType.BASIC_FLOW, AuthenticationProvider.FORM_FLOW
+                ) {
                     requirement = Requirement.CONDITIONAL
                     condition(AuthenticationProvider.CONDITIONAL_LEVEL_OF_AUTHENTICATION) {
 //                        alias = "silver"
@@ -52,7 +54,9 @@ class SpaceOtpFlowService {
                     }
                     execution(AuthenticationProvider.ALLOW_ACCESS, Requirement.REQUIRED)
                 }
-                subFlow("browser-with-conditional-otp-force", FlowType.BASIC_FLOW, AuthenticationProvider.FORM_FLOW) {
+                subFlow(
+                    "browser-with-conditional-otp-force", FlowType.BASIC_FLOW, AuthenticationProvider.FORM_FLOW
+                ) {
                     requirement = Requirement.CONDITIONAL
                     condition(AuthenticationProvider.CONDITIONAL_LEVEL_OF_AUTHENTICATION) {
 //                        alias = "gold"


### PR DESCRIPTION
- Implemented conditional authentication levels in OTP flow for improved security.
- Introduced new authentication providers in `AuthenticationFlowDsl` for better access control.
- Added `ObjectMapper` dependency for JSON processing in OTP flow.
- Standardized MFA function naming to camel case for consistency.
- Introduced `UserDisableMfaCommand` and related event to handle MFA disabling.
- Updated policies and services to support credential removal and MFA deactivation.
- Reformatted `SpaceOtpFlowService.kt` for better readability.
- Removed unused `RealmRepresentation.java` and cleaned up related code.






