### PR TITLE
add user properties to IMProperties for email as username configuration

### DIFF
--- a/im-api/api-config/src/main/kotlin/io/komune/im/api/config/properties/IMProperties.kt
+++ b/im-api/api-config/src/main/kotlin/io/komune/im/api/config/properties/IMProperties.kt
@@ -10,11 +10,16 @@ const val IM_URL_PROPERTY = "connect.im"
 @ConfigurationProperties(prefix = IM_URL_PROPERTY)
 data class IMProperties(
     val organization: OrganizationProperties?,
+    val user: UserProperties?,
     val theme: String? = null,
     val keycloak: KeycloakProperties
 )
 class OrganizationProperties(
     val insee: InseeProperties?
+)
+
+class UserProperties(
+    val emailAsUsername: Boolean = false
 )
 
 class KeycloakProperties(

--- a/im-core/user-core/im-user-core-api/src/main/kotlin/io/komune/im/core/user/api/UserCoreAggregateService.kt
+++ b/im-core/user-core/im-user-core-api/src/main/kotlin/io/komune/im/core/user/api/UserCoreAggregateService.kt
@@ -1,5 +1,6 @@
 package io.komune.im.core.user.api
 
+import io.komune.im.api.config.properties.IMProperties
 import io.komune.im.commons.auth.AuthenticationProvider
 import io.komune.im.commons.utils.mapAsync
 import io.komune.im.core.commons.CoreService
@@ -24,7 +25,9 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
-class UserCoreAggregateService : CoreService(CacheName.User) {
+class UserCoreAggregateService(
+    private val properties: IMProperties
+) : CoreService(CacheName.User) {
     private val logger = LoggerFactory.getLogger(UserCoreAggregateService::class.java)
 
     suspend fun define(command: UserCoreDefineCommand) = mutate(
@@ -122,7 +125,9 @@ class UserCoreAggregateService : CoreService(CacheName.User) {
     }
 
     private fun UserRepresentation.apply(command: UserCoreDefineCommand) = apply {
-        username = username ?: UUID.randomUUID().toString()
+        val emailAsUsername = properties.user?.emailAsUsername ?: false
+
+        username = username ?: if(emailAsUsername) email ?: UUID.randomUUID().toString() else UUID.randomUUID().toString()
         command.email?.let { email = it }
         command.givenName?.let { firstName = it }
         command.familyName?.let { lastName = it }

--- a/im-f2/space/im-space-lib/src/main/kotlin/io/komune/im/f2/space/lib/SpaceAggregateService.kt
+++ b/im-f2/space/im-space-lib/src/main/kotlin/io/komune/im/f2/space/lib/SpaceAggregateService.kt
@@ -128,6 +128,8 @@ class SpaceAggregateService(
             logger.info("Created custom otp flow[${SpaceOtpFlowService.OTP_FLOW_NAME}]: ${command.identifier}")
             spaceOtpFlowService.setAsDefault(keycloakClientProvider, command.identifier)
             logger.info("Set as default browser flow[${SpaceOtpFlowService.OTP_FLOW_NAME}]: ${command.identifier}")
+        } else {
+            logger.info("Skip creating custom otp flow: ${command.identifier}")
         }
     }
 


### PR DESCRIPTION
Update UserCoreAggregateService to utilize user properties for username generation.
Add logging for skipped custom OTP flow creation in SpaceAggregateService.