### PR TITLE
feat(SpaceDefineCommandDTO): add isRegistrationEmailAsUsername property to SpaceSettingsDTO and SpaceSettings data class

### DIFF
--- a/im-f2/space/im-space-domain/src/commonMain/kotlin/io/komune/im/f2/space/domain/command/SpaceDefineCommandDTO.kt
+++ b/im-f2/space/im-space-domain/src/commonMain/kotlin/io/komune/im/f2/space/domain/command/SpaceDefineCommandDTO.kt
@@ -69,6 +69,7 @@ interface SpaceSettingsDTO {
     val registrationAllowed: Boolean?
     val rememberMe: Boolean?
     val resetPasswordAllowed: Boolean?
+    val isRegistrationEmailAsUsername: Boolean?
 }
 
 /**
@@ -78,7 +79,8 @@ interface SpaceSettingsDTO {
 data class SpaceSettings(
     override val registrationAllowed: Boolean?,
     override val rememberMe: Boolean?,
-    override val resetPasswordAllowed: Boolean?
+    override val resetPasswordAllowed: Boolean?,
+    override val isRegistrationEmailAsUsername: Boolean?
 ): SpaceSettingsDTO
 
 /**

--- a/im-f2/space/im-space-lib/src/main/kotlin/io/komune/im/f2/space/lib/SpaceAggregateService.kt
+++ b/im-f2/space/im-space-lib/src/main/kotlin/io/komune/im/f2/space/lib/SpaceAggregateService.kt
@@ -172,6 +172,7 @@ class SpaceAggregateService(
             isRegistrationAllowed = settings.registrationAllowed
             logger.info("Setting isResetPasswordAllowed to ${settings.resetPasswordAllowed}")
             isResetPasswordAllowed = settings.resetPasswordAllowed
+            this.isRegistrationEmailAsUsername = settings.isRegistrationEmailAsUsername
             logger.info("Setting isRememberMe to ${settings.rememberMe}")
             isRememberMe = settings.rememberMe
         }


### PR DESCRIPTION
The isRegistrationEmailAsUsername property is added to allow the system to determine if registration emails can be used as usernames. This enhances the flexibility of user registration options and improves user experience by providing more configuration capabilities. Additionally, the property is integrated into the SpaceAggregateService to ensure it is properly utilized within the service logic.