### PR TITLE
refactor(user-core): rename isRegistrationEmailAsUsername to registra…

### DIFF
--- a/im-f2/space/im-space-domain/src/commonMain/kotlin/io/komune/im/f2/space/domain/command/SpaceDefineCommandDTO.kt
+++ b/im-f2/space/im-space-domain/src/commonMain/kotlin/io/komune/im/f2/space/domain/command/SpaceDefineCommandDTO.kt
@@ -69,7 +69,7 @@ interface SpaceSettingsDTO {
     val registrationAllowed: Boolean?
     val rememberMe: Boolean?
     val resetPasswordAllowed: Boolean?
-    val isRegistrationEmailAsUsername: Boolean?
+    val registrationEmailAsUsername: Boolean?
 }
 
 /**
@@ -80,7 +80,7 @@ data class SpaceSettings(
     override val registrationAllowed: Boolean?,
     override val rememberMe: Boolean?,
     override val resetPasswordAllowed: Boolean?,
-    override val isRegistrationEmailAsUsername: Boolean?
+    override val registrationEmailAsUsername: Boolean?
 ): SpaceSettingsDTO
 
 /**

--- a/im-f2/space/im-space-lib/src/main/kotlin/io/komune/im/f2/space/lib/SpaceAggregateService.kt
+++ b/im-f2/space/im-space-lib/src/main/kotlin/io/komune/im/f2/space/lib/SpaceAggregateService.kt
@@ -172,7 +172,7 @@ class SpaceAggregateService(
             isRegistrationAllowed = settings.registrationAllowed
             logger.info("Setting isResetPasswordAllowed to ${settings.resetPasswordAllowed}")
             isResetPasswordAllowed = settings.resetPasswordAllowed
-            this.isRegistrationEmailAsUsername = settings.isRegistrationEmailAsUsername
+            this.isRegistrationEmailAsUsername = settings.registrationEmailAsUsername
             logger.info("Setting isRememberMe to ${settings.rememberMe}")
             isRememberMe = settings.rememberMe
         }


### PR DESCRIPTION
…tionEmailAsUsername for consistency

refactor(space): update references to isRegistrationEmailAsUsername to registrationEmailAsUsername for clarity The variable name is changed to improve clarity and consistency across the codebase. This enhances readability and aligns with naming conventions, making it easier for developers to understand the purpose of the variable.