### PR TITLE
refactor(UserCoreAggregateService.kt): extract emailAsUsername logic into a separate function for better readability and maintainability

### DIFF
--- a/im-core/user-core/im-user-core-api/src/main/kotlin/io/komune/im/core/user/api/UserCoreAggregateService.kt
+++ b/im-core/user-core/im-user-core-api/src/main/kotlin/io/komune/im/core/user/api/UserCoreAggregateService.kt
@@ -125,11 +125,7 @@ class UserCoreAggregateService(
     }
 
     private suspend fun UserRepresentation.apply(command: UserCoreDefineCommand): UserRepresentation {
-        val emailAsUsername = properties.user?.emailAsUsername
-            ?:  keycloakClientProvider.get().realm().toRepresentation()?.let {
-                logger.info("Using realm[${it.displayName}] configuration for emailAsUsername: ${it.isRegistrationEmailAsUsername}")
-                it.isRegistrationEmailAsUsername
-            } ?: false
+        val emailAsUsername = getIsRegistrationEmailAsUsername()
         return this.apply {
             username =
                 username ?: if (emailAsUsername) email ?: UUID.randomUUID().toString() else UUID.randomUUID().toString()
@@ -156,6 +152,16 @@ class UserCoreAggregateService(
                 .plus(newAttributes)
                 .filterValues { it.filterNotNull().isNotEmpty() }
         }
+    }
+
+    private suspend fun getIsRegistrationEmailAsUsername(): Boolean {
+        val emailAsUsername = properties.user?.emailAsUsername
+            ?: keycloakClientProvider.get().realm().toRepresentation()?.let {
+                logger.info("Using realm[${it.displayName}] configuration " +
+                    "for emailAsUsername: ${it.isRegistrationEmailAsUsername}")
+                it.isRegistrationEmailAsUsername
+            } ?: false
+        return emailAsUsername
     }
 
     private suspend fun UserRepresentation.assignRoles(roles: List<RoleRepresentation>) {


### PR DESCRIPTION
The logic to determine if the email should be used as a username is moved to a new function, getIsRegistrationEmailAsUsername(). This improves code readability and maintainability by encapsulating the logic in a dedicated method, making the main function cleaner and easier to understand.