### PR TITLE
feat(properties): add registrationEmailAsUsername property to LoginSettingsProperties for enhanced user flexibility

### DIFF
--- a/im-script/im-script-core/src/main/kotlin/io/komune/im/script/core/config/properties/SpaceSettingsProperties.kt
+++ b/im-script/im-script-core/src/main/kotlin/io/komune/im/script/core/config/properties/SpaceSettingsProperties.kt
@@ -7,5 +7,6 @@ data class SpaceSettingsProperties(
 data class LoginSettingsProperties(
     val registrationAllowed: Boolean = false,
     val resetPasswordAllowed : Boolean = true,
-    val rememberMe : Boolean = false
+    val rememberMe : Boolean = false,
+    val registrationEmailAsUsername : Boolean = false
 )

--- a/im-script/im-script-space-config/src/main/kotlin/io/komune/im/script/space/config/SpaceConfigScript.kt
+++ b/im-script/im-script-space-config/src/main/kotlin/io/komune/im/script/space/config/SpaceConfigScript.kt
@@ -172,7 +172,8 @@ class SpaceConfigScript(
                     SpaceSettings(
                         registrationAllowed = settings.login.registrationAllowed,
                         rememberMe = settings.login.rememberMe,
-                        resetPasswordAllowed = settings.login.resetPasswordAllowed
+                        resetPasswordAllowed = settings.login.resetPasswordAllowed,
+                        registrationEmailAsUsername = settings.login.registrationEmailAsUsername
                     )
                 }
             ).let { spaceAggregateService.define(it) }

--- a/im-script/im-script-space-create/src/main/kotlin/io/komune/im/script/space/create/SpaceCreateScript.kt
+++ b/im-script/im-script-space-create/src/main/kotlin/io/komune/im/script/space/create/SpaceCreateScript.kt
@@ -117,7 +117,8 @@ class SpaceCreateScript(
                     settings = SpaceSettings(
                         registrationAllowed = properties.settings?.login?.registrationAllowed,
                         rememberMe = properties.settings?.login?.rememberMe,
-                        resetPasswordAllowed = properties.settings?.login?.resetPasswordAllowed
+                        resetPasswordAllowed = properties.settings?.login?.resetPasswordAllowed,
+                        registrationEmailAsUsername = properties.settings?.login?.registrationEmailAsUsername
                     )
                 )
             )


### PR DESCRIPTION
The new property registrationEmailAsUsername allows users to register using their email as their username. This change enhances user experience by providing more flexibility during the registration process. The property is integrated into relevant classes to ensure consistent behavior across the application.