### PR TITLE
feat: rename MFA permission to im_mfa_force_otp and update related logic for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Features act as access control filters, defining the specific contexts in which 
 | **im_apikey_write**             | Ability to modify API keys                | feat_im_all, feat_im_own |
 | **im_space_read**               | Ability to view space data                | feat_im_all              |
 | **im_space_write**              | Ability to modify space data              | feat_im_all              |
-| **im_mfa_force**                | Ability to force MFA on a user            | feat_im_all              |
+| **im_mfa_force_otp**                | Ability to force MFA otp on a user        | feat_im_all              |
 
 ## Getting Started
 

--- a/im-commons/im-commons-domain/src/commonMain/kotlin/io/komune/im/commons/auth/ImPermission.kt
+++ b/im-commons/im-commons-domain/src/commonMain/kotlin/io/komune/im/commons/auth/ImPermission.kt
@@ -4,7 +4,7 @@ import kotlin.js.JsExport
 
 @JsExport
 enum class ImPermission(val identifier: String) {
-    IM_FORCE_MFA("im_mfa_force"),
+    IM_FORCE_MFA_OTP("im_mfa_force_otp"),
 
     IM_USER_READ("im_user_read"),
     IM_USER_ROLE_READ("im_user_role_write"),

--- a/im-f2/space/im-space-lib/src/main/kotlin/io/komune/im/f2/space/lib/flow/ImMfaPasswordOtpFlow.kt
+++ b/im-f2/space/im-space-lib/src/main/kotlin/io/komune/im/f2/space/lib/flow/ImMfaPasswordOtpFlow.kt
@@ -1,0 +1,123 @@
+package io.komune.im.f2.space.lib.flow
+
+import io.komune.im.commons.auth.ImPermission
+
+
+object ImMfaPasswordOtpFlow {
+
+    const val name = "browser-im-mfa-password-otp"
+
+    enum class Acr(val key: String, val level: Int) {
+        PASSWORD_ONLY(key = "password-only", level = 1),
+        PASSWORD_OPTIONAL_OTP(key = "password-optional-otp", level = 2),
+        PASSWORD_OTP(key = "password-otp", level = 3);
+
+        companion object {
+            fun asKeycloakMap() = entries.map { it.key to it.level.toString() }.toMap()
+        }
+    }
+
+    val flow = authenticationFlow(ImMfaPasswordOtpFlow.name) {
+        description = "Custom browser flow with password authentication and conditional OTP"
+        type = FlowType.BASIC_FLOW
+        isBuiltIn = false
+        isTopLevel = true
+
+        execution {
+            provider = AuthenticationProvider.COOKIE
+            requirement = Requirement.ALTERNATIVE
+        }
+
+        execution {
+            provider = AuthenticationProvider.IDP_REDIRECT
+            requirement = Requirement.ALTERNATIVE
+        }
+
+        subFlow {
+            alias = "username-password"
+            type = FlowType.BASIC_FLOW
+            provider = AuthenticationProvider.FORM_FLOW
+
+            execution {
+                provider = AuthenticationProvider.USERNAME_PASSWORD
+                requirement = Requirement.REQUIRED
+            }
+
+            // password-only: Simple authentication (password only)
+            subFlow {
+                alias = "loa-password-only"
+                type = FlowType.BASIC_FLOW
+                provider = AuthenticationProvider.FORM_FLOW
+                requirement = Requirement.CONDITIONAL
+
+                conditionalLoa {
+                    loaConditionLevel = ImMfaPasswordOtpFlow.Acr.PASSWORD_ONLY.level
+                    loaMaxAge = 0
+                }
+
+                execution {
+                    provider = AuthenticationProvider.ALLOW_ACCESS
+                    requirement = Requirement.REQUIRED
+                }
+            }
+
+            // password-optional-otp: Conditional MFA (OTP if required)
+            subFlow {
+                alias = "loa-password-optional-otp"
+                type = FlowType.BASIC_FLOW
+                provider = AuthenticationProvider.FORM_FLOW
+                requirement = Requirement.CONDITIONAL
+
+                conditionalLoa {
+                    loaConditionLevel = ImMfaPasswordOtpFlow.Acr.PASSWORD_OPTIONAL_OTP.level
+                    loaMaxAge = 0
+                }
+
+                execution {
+                    provider = AuthenticationProvider.ALLOW_ACCESS
+                    requirement = Requirement.REQUIRED
+                }
+            }
+
+            // password-otp: Strict MFA enforcement (always require OTP)
+            subFlow {
+                alias = "loa-password-otp"
+                type = FlowType.BASIC_FLOW
+                provider = AuthenticationProvider.FORM_FLOW
+                requirement = Requirement.CONDITIONAL
+
+                conditionalLoa {
+                    loaConditionLevel = ImMfaPasswordOtpFlow.Acr.PASSWORD_OTP.level
+                    loaMaxAge = 0
+                }
+
+                execution {
+                    provider = AuthenticationProvider.OTP_FORM
+                    requirement = Requirement.REQUIRED
+                }
+            }
+
+            // Force OTP for users with the "force-mfa" role
+            subFlow {
+                alias = "force-mfa-user-role-${ImPermission.IM_FORCE_MFA_OTP.identifier}"
+                type = FlowType.BASIC_FLOW
+                provider = AuthenticationProvider.FORM_FLOW
+                requirement = Requirement.CONDITIONAL
+
+                conditional {
+                    provider = AuthenticationProvider.CONDITIONAL_USER_ROLE
+                    config(
+                        "role" to ImPermission.IM_FORCE_MFA_OTP.identifier,
+                        "condUserRole" to ImPermission.IM_FORCE_MFA_OTP.identifier
+                    )
+                }
+
+
+                execution {
+                    provider = AuthenticationProvider.OTP_FORM
+                    requirement = Requirement.REQUIRED
+                }
+            }
+        }
+    }
+}

--- a/im-f2/space/im-space-lib/src/main/kotlin/io/komune/im/f2/space/lib/flow/SpaceOtpFlowService.kt
+++ b/im-f2/space/im-space-lib/src/main/kotlin/io/komune/im/f2/space/lib/flow/SpaceOtpFlowService.kt
@@ -6,18 +6,10 @@ import org.springframework.stereotype.Service
 
 @Service
 class SpaceOtpFlowService {
+
     companion object {
-        const val OTP_FLOW_NAME = "browser-with-conditional-otp"
         const val OTP_FLOW_USER_ATTRIBUTE = "mfa"
         const val OTP_FLOW_USER_ATTRIBUTE_VALUE = "OTP"
-
-        val ACR = mapOf(
-//            "bronze" to "1",
-//            "silver" to "2",
-//            "gold" to "3",
-            "force-password" to "4",
-            "force-mfa" to "5"
-        )
     }
 
     suspend fun create(keycloakClientProvider: KeycloakClientProvider, space: String) {
@@ -30,47 +22,7 @@ class SpaceOtpFlowService {
      *   Browser Flow (Top-Level Flow)
      */
     private fun create(authFlowsClient: AuthenticationManagementResource) {
-        authenticationFlow("browser-with-conditional-otp") {
-            description = "Custom browser flow with conditional OTP"
-            type = FlowType.BASIC_FLOW
-            isBuiltIn = false
-            isTopLevel = true
-
-            execution(AuthenticationProvider.COOKIE, Requirement.ALTERNATIVE)
-            execution(AuthenticationProvider.IDP_REDIRECT, Requirement.ALTERNATIVE)
-
-            subFlow("browser-with-conditional-otp-forms", FlowType.BASIC_FLOW, AuthenticationProvider.FORM_FLOW) {
-                execution(AuthenticationProvider.USERNAME_PASSWORD, Requirement.REQUIRED)
-                subFlow(
-                    "browser-with-conditional-otp-password", FlowType.BASIC_FLOW, AuthenticationProvider.FORM_FLOW
-                ) {
-                    requirement = Requirement.CONDITIONAL
-                    condition(AuthenticationProvider.CONDITIONAL_LEVEL_OF_AUTHENTICATION) {
-//                        alias = "silver"
-                        config(
-                            "loa-condition-level" to "4",
-                            "loa-max-age" to "0"
-                        )
-                    }
-                    execution(AuthenticationProvider.ALLOW_ACCESS, Requirement.REQUIRED)
-                }
-                subFlow(
-                    "browser-with-conditional-otp-force", FlowType.BASIC_FLOW, AuthenticationProvider.FORM_FLOW
-                ) {
-                    requirement = Requirement.CONDITIONAL
-                    condition(AuthenticationProvider.CONDITIONAL_LEVEL_OF_AUTHENTICATION) {
-//                        alias = "gold"
-                        config(
-                            "loa-condition-level" to "5",
-                            "loa-max-age" to "0"
-                        )
-                    }
-                    execution(AuthenticationProvider.OTP_FORM, Requirement.REQUIRED)
-                }
-
-
-            }
-        }.deploy(authFlowsClient)
+        ImMfaPasswordOtpFlow.flow.deploy(authFlowsClient)
     }
 
     suspend fun setAsDefault(keycloakClientProvider: KeycloakClientProvider, space: String) {
@@ -78,7 +30,7 @@ class SpaceOtpFlowService {
         val realmResource = keycloakClient.keycloak.realm(space)
 
         val realmRepresentation = realmResource.toRepresentation()
-        realmRepresentation.browserFlow = OTP_FLOW_NAME
+        realmRepresentation.browserFlow = ImMfaPasswordOtpFlow.name
         realmResource.update(realmRepresentation)
     }
 }

--- a/im-f2/user/im-user-domain/src/commonMain/kotlin/io/komune/im/f2/user/domain/policies/UserPolicies.kt
+++ b/im-f2/user/im-user-domain/src/commonMain/kotlin/io/komune/im/f2/user/domain/policies/UserPolicies.kt
@@ -60,7 +60,7 @@ object UserPolicies {
      * User can disable mfa
      */
     fun canDisableMfa(authedUser: AuthedUserDTO, user: UserDTO): Boolean {
-        return isMySelf(authedUser, user)
+        return isMySelf(authedUser, user) && !authedUser.hasRole(ImPermission.IM_FORCE_MFA_OTP)
     }
 
     /**

--- a/im-keycloak/keycloak-plugin/im-keycloak-db-schema-migration/src/main/resources/META-INF/im-changelog-0.21.0-im-new-permissions.xml
+++ b/im-keycloak/keycloak-plugin/im-keycloak-db-schema-migration/src/main/resources/META-INF/im-changelog-0.21.0-im-new-permissions.xml
@@ -23,9 +23,9 @@
         </sql>
         <sql>
             INSERT INTO keycloak_role (id, name, description, realm_id)
-            SELECT uuid_generate_v4(), 'im_mfa_force', 'Ability to force MFA', id
+            SELECT uuid_generate_v4(), 'im_mfa_force_otp', 'Ability to force MFA', id
             FROM realm
-            WHERE NOT EXISTS (SELECT 1 FROM keycloak_role WHERE name = 'im_mfa_force' AND realm_id = id)
+            WHERE NOT EXISTS (SELECT 1 FROM keycloak_role WHERE name = 'im_mfa_force_otp' AND realm_id = id)
               AND name != 'master';
         </sql>
     </changeSet>

--- a/im-script/im-script-space-create/src/main/resources/imPermissions.json
+++ b/im-script/im-script-space-create/src/main/resources/imPermissions.json
@@ -55,7 +55,7 @@
     "description": "Ability to modify space data",
     "features":  [["feat_im_all"]]
 }, {
-    "name": "im_mfa_force",
+    "name": "im_mfa_force_otp",
     "description": "Ability to force MFA on user",
     "features":  [["feat_im_all"]]
 }]


### PR DESCRIPTION
The permission for forcing MFA is renamed from `im_mfa_force` to `im_mfa_force_otp` to better reflect its functionality. This change is propagated throughout the codebase, including updates to the README, permission checks, and the authentication flow. The updates ensure clarity and consistency in the naming conventions, which helps in maintaining the code and understanding its purpose. Additionally, a new `ImMfaPasswordOtpFlow` class is introduced to encapsulate the logic related to the MFA OTP flow, enhancing modularity and readability.