### PR TITLE
refactor(mfa): simplify Acr enum by removing PASSWORD_OPTIONAL_OTP

### DIFF
--- a/im-core/mfa-core/im-mfa-core-domain/src/commonMain/kotlin/io/komune/im/core/mfa/domain/model/ImMfaPasswordOtpFlow.kt
+++ b/im-core/mfa-core/im-mfa-core-domain/src/commonMain/kotlin/io/komune/im/core/mfa/domain/model/ImMfaPasswordOtpFlow.kt
@@ -8,8 +8,7 @@ object ImMfaPasswordOtpFlow {
 
     enum class Acr(val key: String, val level: Int) {
         PASSWORD_ONLY(key = "password-only", level = 1),
-        PASSWORD_OPTIONAL_OTP(key = "password-optional-otp", level = 2),
-        PASSWORD_OTP(key = "password-otp", level = 3);
+        PASSWORD_OTP(key = "password-otp", level = 2);
 
         companion object {
             fun asKeycloakMap() = entries.map { it.key to it.level.toString() }.toMap()


### PR DESCRIPTION
The Acr enum is simplified by removing the PASSWORD_OPTIONAL_OTP value, which reduces complexity and clarifies the authentication flow levels. This change ensures that the levels are more straightforward and easier to understand, improving maintainability.