### PR TITLE
feat(ImMfaPasswordOtpFlow): add conditional sub-flow execution for MFA requirements

### DIFF
--- a/im-core/mfa-core/im-mfa-core-domain/src/commonMain/kotlin/io/komune/im/core/mfa/domain/model/ImMfaPasswordOtpFlow.kt
+++ b/im-core/mfa-core/im-mfa-core-domain/src/commonMain/kotlin/io/komune/im/core/mfa/domain/model/ImMfaPasswordOtpFlow.kt
@@ -96,6 +96,17 @@ object ImMfaPasswordOtpFlow {
                         requirement = Requirement.REQUIRED
                     }
 
+                    conditional {
+                        provider = AuthenticationProvider.CONDITIONAL_SUB_FLOW_EXECUTED
+                        requirement = Requirement.REQUIRED
+                        config(
+                            "check_result" to "not-executed",
+                            "default.reference.maxAge" to "",
+                            "default.reference.value" to "",
+                            "flow_to_check"  to "force-mfa-user-role-${ImPermission.IM_FORCE_MFA_OTP.identifier}"
+                        )
+                    }
+
                     execution {
                         provider = AuthenticationProvider.OTP_FORM
                         requirement = Requirement.REQUIRED
@@ -104,7 +115,7 @@ object ImMfaPasswordOtpFlow {
                 subFlow("force-mfa-user-role-${ImPermission.IM_FORCE_MFA_OTP.identifier}") {
                     type = FlowType.BASIC_FLOW
                     provider = AuthenticationProvider.FORM_FLOW
-                    requirement = Requirement.CONDITIONAL  // ✅ Change to REQUIRED to stop the flow
+                    requirement = Requirement.CONDITIONAL
 
                     conditional {
                         provider = AuthenticationProvider.CONDITIONAL_USER_ROLE


### PR DESCRIPTION
The new conditional block allows for a more flexible authentication flow by checking if a specific condition is met before executing the MFA process. This enhances the security and user experience by ensuring that the MFA is only triggered when necessary, based on the user's role and previous actions.