### PR TITLE
feat(ClientCreateCommand): change baseUrl and adminUrl to nullable types for better flexibility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,4 @@ kotlin.incremental.js.ir=true
 kotlin.js.ir.output.granularity=whole-program
 #org.gradle.parallel=true
 
-KEYCLOAK_VERSION=26.1.2
+KEYCLOAK_VERSION=26.1.4

--- a/im-core/client-core/im-client-core-domain/src/commonMain/kotlin/io/komune/im/core/client/domain/command/ClientCreateCommand.kt
+++ b/im-core/client-core/im-client-core-domain/src/commonMain/kotlin/io/komune/im/core/client/domain/command/ClientCreateCommand.kt
@@ -15,8 +15,8 @@ data class ClientCreateCommand(
     val isStandardFlowEnabled: Boolean,
     val rootUrl: String? = null,
     val redirectUris: List<String> = emptyList(),
-    val baseUrl: String = "",
-    val adminUrl: String = "",
+    val baseUrl: String? = null,
+    val adminUrl: String? = null,
     val webOrigins: List<String> = emptyList(),
     val additionalAccessTokenClaim: List<String> = emptyList()
 )

--- a/im-script/im-script-core/src/main/kotlin/io/komune/im/script/core/model/AppClient.kt
+++ b/im-script/im-script-core/src/main/kotlin/io/komune/im/script/core/model/AppClient.kt
@@ -6,5 +6,9 @@ data class AppClient(
     val clientId: ClientIdentifier,
     val clientSecret: String?,
     val roles: List<String>?,
-    val realmManagementRoles: List<String>?
+    val realmManagementRoles: List<String>?,
+    /*
+    * To be able to redirect to the home page of the client application
+    */
+    val homeUrl: String? = null,
 )

--- a/im-script/im-script-init/src/main/kotlin/io/komune/im/script/init/ImInitScript.kt
+++ b/im-script/im-script-init/src/main/kotlin/io/komune/im/script/init/ImInitScript.kt
@@ -54,7 +54,8 @@ class ImInitScript(
             clientId = clientId,
             clientSecret = clientSecret,
             roles = listOf("admin"),
-            realmManagementRoles = emptyList()
+            realmManagementRoles = emptyList(),
+            homeUrl = null
         ).let { clientInitService.initAppClient(it) }
 
         val realmClientId = clientCoreFinderService.getByIdentifier("master-realm").id

--- a/infra/docker-compose/docker-compose-keycloak.yml
+++ b/infra/docker-compose/docker-compose-keycloak.yml
@@ -14,6 +14,8 @@ services:
       PROXY_ADDRESS_FORWARDING: "true"
       JDBC_PARAMS: "ssl=false"
       KC_HOSTNAME_STRICT_HTTPS: "false"
+#    command:
+#      - "--log-level=trace"
     ports:
       - '8080:8080'
     networks:

--- a/infra/docker/keycloak/Dockerfile
+++ b/infra/docker/keycloak/Dockerfile
@@ -1,6 +1,6 @@
 ARG KEYCLOAK_VERSION
 
-FROM quay.io/keycloak/keycloak:26.1.2 AS builder
+FROM quay.io/keycloak/keycloak:26.1.4 AS builder
 ENV KC_DB=postgres
 ENV KC_FEATURES=passkeys
 ENV KC_LOG_LEVEL=INFO
@@ -12,7 +12,7 @@ ENV KC_HTTP_RELATIVE_PATH=${KC_HTTP_RELATIVE_PATH}
 COPY im-keycloak/keycloak-plugin/build/libs/keycloak-plugin-with-dependencies.jar /opt/keycloak/providers/im-event-http.jar
 RUN /opt/keycloak/bin/kc.sh build --db=postgres
 
-FROM quay.io/keycloak/keycloak:26.1.2
+FROM quay.io/keycloak/keycloak:26.1.4
 COPY --from=builder /opt/keycloak/ /opt/keycloak/
 WORKDIR /opt/keycloak
 


### PR DESCRIPTION
feat(AppClient): add homeUrl property to support redirection to client application home page refactor(ClientInitService): extract client creation and role granting logic into separate functions for better readability and maintainability The baseUrl and adminUrl properties are now nullable, allowing for more flexible configurations. A new homeUrl property is added to the AppClient to facilitate redirection. The client creation and role granting logic is refactored into separate functions to improve code organization and clarity.