### PR TITLE
fix(ci): migrate kotkin-js to FIXERS_PUBLISH_NPMJS_TOKEN

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -36,8 +36,7 @@ jobs:
     with:
       make-file: 'infra/make/libsJs.mk'
     secrets:
-      NPM_PKG_STAGE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      NPM_PKG_PROMOTE_TOKEN: ${{ secrets.NPM_PKG_NPMJS_TOKEN}}
+      FIXERS_PUBLISH_NPMJS_TOKEN: ${{ secrets.NPM_PKG_NPMJS_TOKEN }}
       PKG_GITHUB_USERNAME: ${{ github.actor }}
       PKG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -36,7 +36,7 @@ jobs:
     with:
       make-file: 'infra/make/libsJs.mk'
     secrets:
-      FIXERS_PUBLISH_NPMJS_TOKEN: ${{ secrets.NPM_PKG_NPMJS_TOKEN }}
+      FIXERS_PUBLISH_NPMJS_TOKEN: ${{ secrets.FIXERS_PUBLISH_NPMJS_TOKEN }}
       PKG_GITHUB_USERNAME: ${{ github.actor }}
       PKG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Delete NPM_PKG_STAGE_TOKEN caller pass-through (reusable workflow now reads secrets.GITHUB_TOKEN directly)
- Rename NPM_PKG_PROMOTE_TOKEN to FIXERS_PUBLISH_NPMJS_TOKEN (source stays secrets.NPM_PKG_NPMJS_TOKEN at org level)

## Depends on
- komune-io/fixers-gradle#161 (fix/fixers-publish-npm-token) must merge first

## Test plan
- [ ] kotkin-js CI job completes after org secret NPM_PKG_NPMJS_TOKEN is rotated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to modify secret handling for package publishing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->