### PR TITLE
feat(ci): normalize secrets to FIXERS_PUBLISH_* / FIXERS_* namespace

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -20,13 +20,13 @@ jobs:
     with:
       make-file: 'infra/make/libs.mk'
     secrets:
-      GPG_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-      GPG_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
-      PKG_GITHUB_USERNAME: ${{ github.actor }}
-      PKG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      JRELEASER_MAVENCENTRAL_USERNAME: ${{ secrets.JRELEASER_MAVENCENTRAL_USERNAME }}
-      JRELEASER_MAVENCENTRAL_PASSWORD: ${{ secrets.JRELEASER_MAVENCENTRAL_PASSWORD }}
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      FIXERS_PUBLISH_SIGNING_GPG_KEY: ${{ secrets.FIXERS_PUBLISH_SIGNING_GPG_KEY }}
+      FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD: ${{ secrets.FIXERS_PUBLISH_SIGNING_GPG_KEY_PASSWORD }}
+      FIXERS_PUBLISH_GITHUB_USERNAME: ${{ github.actor }}
+      FIXERS_PUBLISH_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_USERNAME }}
+      FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD }}
+      FIXERS_SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN }}
 
   kotkin-js:
     uses: komune-io/fixers-gradle/.github/workflows/make-kotlin-npm-workflow.yml@main
@@ -52,12 +52,12 @@ jobs:
       with-promote-docker-registry-login: 'true'
       docker-buildx-platform: linux/amd64,linux/arm64
     secrets:
-      PKG_GITHUB_USERNAME: ${{ github.actor }}
-      PKG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      FIXERS_PUBLISH_GITHUB_USERNAME: ${{ github.actor }}
+      FIXERS_PUBLISH_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       DOCKER_STAGE_USERNAME: ${{ github.actor }}
       DOCKER_STAGE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-      DOCKER_PROMOTE_USERNAME: ${{ secrets.DOCKER_IO_USERNAME }}
-      DOCKER_PROMOTE_PASSWORD: ${{ secrets.DOCKER_IO_PASSWORD }}
+      DOCKER_PROMOTE_USERNAME: ${{ secrets.FIXERS_DOCKER_HUB_USERNAME }}
+      DOCKER_PROMOTE_PASSWORD: ${{ secrets.FIXERS_DOCKER_HUB_PASSWORD }}
 
   docs:
     uses: komune-io/fixers-gradle/.github/workflows/publish-storybook-workflow.yml@main
@@ -74,9 +74,9 @@ jobs:
       storybook-static-dir: storybook-static
       with-setup-npm-github-pkg: 'false'
     secrets:
-      NPM_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+      FIXERS_PUBLISH_NPM_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CHROMATIC_PROJECT_TOKEN: ${{ secrets.FIXERS_CHROMATIC_PROJECT_TOKEN }}
       DOCKER_STAGE_USERNAME: ${{ github.actor }}
       DOCKER_STAGE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-      DOCKER_PROMOTE_USERNAME: ${{ secrets.DOCKER_IO_USERNAME }}
-      DOCKER_PROMOTE_PASSWORD: ${{ secrets.DOCKER_IO_PASSWORD }}
+      DOCKER_PROMOTE_USERNAME: ${{ secrets.FIXERS_DOCKER_HUB_USERNAME }}
+      DOCKER_PROMOTE_PASSWORD: ${{ secrets.FIXERS_DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -28,7 +28,7 @@ jobs:
       FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD: ${{ secrets.FIXERS_PUBLISH_MAVEN_CENTRAL_PASSWORD }}
       FIXERS_SONAR_TOKEN: ${{ secrets.FIXERS_SONAR_TOKEN }}
 
-  kotkin-js:
+  kotlin-js:
     uses: komune-io/fixers-gradle/.github/workflows/make-kotlin-npm-workflow.yml@main
     permissions:
       contents: read

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -75,7 +75,6 @@ jobs:
       with-setup-npm-github-pkg: 'false'
     secrets:
       FIXERS_PUBLISH_NPM_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      CHROMATIC_PROJECT_TOKEN: ${{ secrets.FIXERS_CHROMATIC_PROJECT_TOKEN }}
       DOCKER_STAGE_USERNAME: ${{ github.actor }}
       DOCKER_STAGE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
       DOCKER_PROMOTE_USERNAME: ${{ secrets.FIXERS_DOCKER_HUB_USERNAME }}

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -36,10 +36,9 @@ jobs:
     with:
       make-file: 'infra/make/libsJs.mk'
     secrets:
-      NPM_PKG_STAGE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      NPM_PKG_PROMOTE_TOKEN: ${{ secrets.NPM_PKG_NPMJS_TOKEN}}
-      PKG_GITHUB_USERNAME: ${{ github.actor }}
-      PKG_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      FIXERS_PUBLISH_NPMJS_TOKEN: ${{ secrets.FIXERS_PUBLISH_NPMJS_TOKEN }}
+      FIXERS_PUBLISH_GITHUB_USERNAME: ${{ github.actor }}
+      FIXERS_PUBLISH_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   docker:
     uses: komune-io/fixers-gradle/.github/workflows/make-jvm-workflow.yml@main
@@ -74,7 +73,6 @@ jobs:
       storybook-static-dir: storybook-static
       with-setup-npm-github-pkg: 'false'
     secrets:
-      FIXERS_PUBLISH_NPM_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       DOCKER_STAGE_USERNAME: ${{ github.actor }}
       DOCKER_STAGE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
       DOCKER_PROMOTE_USERNAME: ${{ secrets.FIXERS_DOCKER_HUB_USERNAME }}

--- a/infra/docker/storybook/Dockerfile
+++ b/infra/docker/storybook/Dockerfile
@@ -8,11 +8,11 @@ COPY storybook ./storybook
 
 WORKDIR /app/storybook
 
-ARG NPM_AUTH_TOKEN
+ARG FIXERS_PUBLISH_NPM_GITHUB_TOKEN
 RUN printf "\
 @komune-io:registry=https://npm.pkg.github.com\n\
 //npm.pkg.github.com/:_authToken=%s\n\
-" "${NPM_AUTH_TOKEN}" > .npmrc
+" "${FIXERS_PUBLISH_NPM_GITHUB_TOKEN}" > .npmrc
 
 
 RUN if [ ! -d "./storybook-static" ]; then \

--- a/infra/make/docs.mk
+++ b/infra/make/docs.mk
@@ -25,7 +25,7 @@ lint-docker-storybook:
 
 package-storybook:
 	@docker build --no-cache  --platform=linux/amd64 \
-		--build-arg NPM_AUTH_TOKEN=${NPM_AUTH_TOKEN} \
+		--build-arg FIXERS_PUBLISH_NPM_GITHUB_TOKEN=${FIXERS_PUBLISH_NPM_GITHUB_TOKEN} \
 		-f ${STORYBOOK_DOCKERFILE} \
 		-t ${STORYBOOK_IMG} .
 


### PR DESCRIPTION
## Summary
- Rename libs + docker + docs caller pass-throughs from legacy names to FIXERS_PUBLISH_* / FIXERS_*
- Storybook Dockerfile ARG + docs.mk --build-arg renamed NPM_AUTH_TOKEN to FIXERS_PUBLISH_NPM_GITHUB_TOKEN
- kotkin-js job unchanged (handled by fix/fixers-publish-npm-token branch)

## Depends on
- komune-io/fixers-gradle#162 (fix/normalize-secrets) must merge first

## Test plan
- [ ] libs + docker + docs + kotkin-js CI jobs all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflows to remap publishing and scan credentials and streamline secret handling across reusable jobs.
  * Adjusted Docker/Storybook build configuration to use the revised authentication build argument for package publishing.
  * These internal infrastructure changes do not affect end-user functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->